### PR TITLE
Fixes extreme memory usage

### DIFF
--- a/nurble.php
+++ b/nurble.php
@@ -1,18 +1,23 @@
 <?php
 
-function nurble($text){
-    $nouns = file("nouns.txt", FILE_IGNORE_NEW_LINES);
-    $text = strtoupper($text);
-    $words = preg_split(
-        '/\w/',
-        preg_replace('/[^a-z ]/', '', strtolower($text)));
+function nurble($text)
+{
+    $nouns = file('nouns.txt', FILE_IGNORE_NEW_LINES);
+    $isMatch = (bool) preg_match_all('/\b[a-zA-Z]+\b/', $text, $matches);
 
-    foreach($words as $word){
-        if(!in_array($word, $nouns)){
-            $pattern = '/(\b)' . $word . '(\b)/i';
-            $replacement = '\1<span class="nurble">nurble</span>\2';
-            $text = preg_replace($pattern, $replacement, $text);
-        }
+    if ($isMatch === true) {
+        $words = array_unique(
+            array_filter($matches[0], function ($word) use ($nouns) {
+                return  in_array($word, $nouns) === false;
+            })
+        );
+
+        $pattern = sprintf(
+            '/(\b)%s(\b)/',
+            implode('(\b)|(\b)', $words)
+        );
+        $replacement = '\1<span class="nurble">nurble</span>\2';
+        $text = preg_replace($pattern, $replacement, $text);
     }
 
     return str_replace("\n", '<br>', $text);


### PR DESCRIPTION
I'm not sure if you'd be interested in these changes but I ran into memory issue with large texts due to the way the code is structured. This pull-request fixes that by placing the memory intensive logic (the preg_replace call) outside of the foreach loop and replacing the foreach with an `array_filter`. 

According to various online benchmarks this does make the code minutely slower. Trade-offs, right? 😄 
